### PR TITLE
Remove AtomsTesting

### DIFF
--- a/Examples/CocktailExample/CocktailExample.xcodeproj/project.pbxproj
+++ b/Examples/CocktailExample/CocktailExample.xcodeproj/project.pbxproj
@@ -18,8 +18,6 @@
 		AB1260FB29ED6B6F00E7BDCD /* CocktaiItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1260FA29ED6B6F00E7BDCD /* CocktaiItemView.swift */; };
 		AB1260FD29ED6BAE00E7BDCD /* CocktailImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB1260FC29ED6BAE00E7BDCD /* CocktailImageView.swift */; };
 		AB578F6F29ED6F3C00B45B1A /* CocktailExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB578F6E29ED6F3C00B45B1A /* CocktailExampleTests.swift */; };
-		AB578F7629ED6F4800B45B1A /* AtomsTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AB578F7529ED6F4800B45B1A /* AtomsTesting */; };
-		AB578F7829ED6F4800B45B1A /* AtomsTesting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = AB578F7529ED6F4800B45B1A /* AtomsTesting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,7 +37,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				AB578F7829ED6F4800B45B1A /* AtomsTesting in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -75,7 +72,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB578F7629ED6F4800B45B1A /* AtomsTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -188,7 +184,6 @@
 			);
 			name = CocktailExampleTests;
 			packageProductDependencies = (
-				AB578F7529ED6F4800B45B1A /* AtomsTesting */,
 			);
 			productName = CocktailExampleTests;
 			productReference = AB578F6C29ED6F3C00B45B1A /* CocktailExampleTests.xctest */;
@@ -529,10 +524,6 @@
 		AB1260F229ED6A8E00E7BDCD /* Atoms */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Atoms;
-		};
-		AB578F7529ED6F4800B45B1A /* AtomsTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AtomsTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Examples/CocktailExample/CocktailExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/CocktailExample/CocktailExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bangerang/swift-async-expectations.git",
       "state" : {
-        "revision" : "016a5e6e295f5458e6fd01ee404757d9ca339613",
-        "version" : "0.0.1"
+        "revision" : "1f65a7dcc7810eb4e5108e007dcfc03466aac0e8",
+        "version" : "0.1.0"
       }
     },
     {
@@ -16,6 +16,24 @@
       "state" : {
         "revision" : "84b30e1af72e0ffe6dfbfe39d53b8173caacf224",
         "version" : "0.10.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Examples/CocktailExample/CocktailExampleTests/CocktailExampleTests.swift
+++ b/Examples/CocktailExample/CocktailExampleTests/CocktailExampleTests.swift
@@ -6,7 +6,6 @@
 //
 
 import XCTest
-import AtomsTesting
 @testable import CocktailExample
 import Atoms
 

--- a/Examples/SignupExample/SignupExample.xcodeproj/project.pbxproj
+++ b/Examples/SignupExample/SignupExample.xcodeproj/project.pbxproj
@@ -14,8 +14,6 @@
 		AB39745B29ED78F9003ABB08 /* Atoms in Frameworks */ = {isa = PBXBuildFile; productRef = AB39745A29ED78F9003ABB08 /* Atoms */; };
 		AB39745D29ED790F003ABB08 /* Atoms.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB39745C29ED790F003ABB08 /* Atoms.swift */; };
 		AB39746529ED797D003ABB08 /* SignupExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB39746429ED797D003ABB08 /* SignupExampleTests.swift */; };
-		AB39746C29ED79FE003ABB08 /* AtomsTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AB39746B29ED79FE003ABB08 /* AtomsTesting */; };
-		AB39746E29ED79FE003ABB08 /* AtomsTesting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = AB39746B29ED79FE003ABB08 /* AtomsTesting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,7 +33,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				AB39746E29ED79FE003ABB08 /* AtomsTesting in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -67,7 +64,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB39746C29ED79FE003ABB08 /* AtomsTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -176,7 +172,6 @@
 			);
 			name = SignupExampleTests;
 			packageProductDependencies = (
-				AB39746B29ED79FE003ABB08 /* AtomsTesting */,
 			);
 			productName = SignupExampleTests;
 			productReference = AB39746229ED797D003ABB08 /* SignupExampleTests.xctest */;
@@ -513,10 +508,6 @@
 		AB39745A29ED78F9003ABB08 /* Atoms */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Atoms;
-		};
-		AB39746B29ED79FE003ABB08 /* AtomsTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AtomsTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Examples/SignupExample/SignupExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SignupExample/SignupExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bangerang/swift-async-expectations.git",
       "state" : {
-        "revision" : "016a5e6e295f5458e6fd01ee404757d9ca339613",
-        "version" : "0.0.1"
+        "revision" : "1f65a7dcc7810eb4e5108e007dcfc03466aac0e8",
+        "version" : "0.1.0"
       }
     },
     {
@@ -16,6 +16,24 @@
       "state" : {
         "revision" : "84b30e1af72e0ffe6dfbfe39d53b8173caacf224",
         "version" : "0.10.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Examples/SignupExample/SignupExampleTests/SignupExampleTests.swift
+++ b/Examples/SignupExample/SignupExampleTests/SignupExampleTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import SignupExample
-import AtomsTesting
 import Atoms
 
 final class SignupExampleTests: XCTestCase {

--- a/Examples/TodoExample/TodoExample.xcodeproj/project.pbxproj
+++ b/Examples/TodoExample/TodoExample.xcodeproj/project.pbxproj
@@ -17,8 +17,6 @@
 		AB30B9D529ED885900E4E2E3 /* TodoItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB30B9D429ED885900E4E2E3 /* TodoItemView.swift */; };
 		AB30B9D729ED886D00E4E2E3 /* NewTodoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB30B9D629ED886D00E4E2E3 /* NewTodoView.swift */; };
 		AB30B9DF29ED91F500E4E2E3 /* TodoExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB30B9DE29ED91F500E4E2E3 /* TodoExampleTests.swift */; };
-		AB30B9E629ED91FF00E4E2E3 /* AtomsTesting in Frameworks */ = {isa = PBXBuildFile; productRef = AB30B9E529ED91FF00E4E2E3 /* AtomsTesting */; };
-		AB30B9E829ED91FF00E4E2E3 /* AtomsTesting in Embed Frameworks */ = {isa = PBXBuildFile; productRef = AB30B9E529ED91FF00E4E2E3 /* AtomsTesting */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,7 +36,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				AB30B9E829ED91FF00E4E2E3 /* AtomsTesting in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -73,7 +70,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				AB30B9E629ED91FF00E4E2E3 /* AtomsTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -185,7 +181,6 @@
 			);
 			name = TodoExampleTests;
 			packageProductDependencies = (
-				AB30B9E529ED91FF00E4E2E3 /* AtomsTesting */,
 			);
 			productName = TodoExampleTests;
 			productReference = AB30B9DC29ED91F500E4E2E3 /* TodoExampleTests.xctest */;
@@ -525,10 +520,6 @@
 		AB30B9CE29ED87E200E4E2E3 /* Atoms */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Atoms;
-		};
-		AB30B9E529ED91FF00E4E2E3 /* AtomsTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AtomsTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Examples/TodoExample/TodoExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/TodoExample/TodoExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bangerang/swift-async-expectations.git",
       "state" : {
-        "revision" : "016a5e6e295f5458e6fd01ee404757d9ca339613",
-        "version" : "0.0.1"
+        "revision" : "1f65a7dcc7810eb4e5108e007dcfc03466aac0e8",
+        "version" : "0.1.0"
       }
     },
     {
@@ -16,6 +16,24 @@
       "state" : {
         "revision" : "84b30e1af72e0ffe6dfbfe39d53b8173caacf224",
         "version" : "0.10.2"
+      }
+    },
+    {
+      "identity" : "swift-docc-plugin",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-plugin",
+      "state" : {
+        "revision" : "9b1258905c21fc1b97bf03d1b4ca12c4ec4e5fda",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-docc-symbolkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-docc-symbolkit",
+      "state" : {
+        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
+        "version" : "1.0.0"
       }
     },
     {

--- a/Examples/TodoExample/TodoExampleTests/TodoExampleTests.swift
+++ b/Examples/TodoExample/TodoExampleTests/TodoExampleTests.swift
@@ -7,7 +7,6 @@
 
 import XCTest
 @testable import TodoExample
-import AtomsTesting
 import Atoms
 
 final class TodoExampleTests: XCTestCase {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bangerang/swift-async-expectations.git",
       "state" : {
-        "revision" : "016a5e6e295f5458e6fd01ee404757d9ca339613",
-        "version" : "0.0.1"
+        "revision" : "1f65a7dcc7810eb4e5108e007dcfc03466aac0e8",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -7,32 +7,24 @@ let package = Package(
     name: "Atoms",
     platforms: [.iOS(.v13), .macOS(.v10_15)],
     products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
             name: "Atoms",
             targets: ["Atoms"]),
-        .library(
-            name: "AtomsTesting",
-            type: .dynamic,
-            targets: ["AtomsTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/bangerang/swift-async-expectations.git", from: "0.0.1"),
+        .package(url: "https://github.com/bangerang/swift-async-expectations.git", from: "0.1.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.3.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.1.0"),
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "0.2.0")
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "Atoms",
-            dependencies: [.product(name: "CustomDump", package: "swift-custom-dump")]
+            dependencies: [
+                .product(name: "CustomDump", package: "swift-custom-dump"),
+                .product(name: "AsyncExpectations", package: "swift-async-expectations")
+            ]
         ),
-        .target(name: "AtomsTesting", dependencies: [
-            .product(name: "AsyncExpectations", package: "swift-async-expectations"), "Atoms"
-        ]),
         .testTarget(
             name: "AtomsTests",
             dependencies: ["Atoms", .product(name: "AsyncExpectations", package: "swift-async-expectations")]),

--- a/Sources/Atoms/Internal/ExportAsyncExpectations.swift
+++ b/Sources/Atoms/Internal/ExportAsyncExpectations.swift
@@ -1,2 +1,3 @@
-import Foundation
+#if DEBUG
 @_exported import AsyncExpectations
+#endif

--- a/Tests/AtomsTests/AtomsTests.swift
+++ b/Tests/AtomsTests/AtomsTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 @testable import Atoms
-import AsyncExpectations
 import Combine
 
 final class swift_atomsTests: XCTestCase {


### PR DESCRIPTION
[AsyncExpectations](https://github.com/bangerang/swift-async-expectations) can now be imported to the main target. 
This means that the AtomsTesting library is no longer necessary.